### PR TITLE
Make hexxy directly installable via go

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@
 requirements: Go 1.20+ (it may build with earlier versions as well but I have not tested them) and git
 
 ```sh
-git clone https://github.com/sweetbbak/hexxy && cd hexxy
-go build
+go install github.com/sweetbbak/hexxy@latest
 ```
 
 On ArchLinux ([hexxy-git](https://aur.archlinux.org/packages/hexxy-git)), e.g.:

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module hexxy
+module github.com/sweetbbak/hexxy
 
 go 1.21.5
 


### PR DESCRIPTION
Minor change to go.mod so hexxy can be installed using go without git clone.
Although, not sure but even if not on pkg.go.dev it should be able to be iinstalled this way anyway.